### PR TITLE
Update CommercePosTransactionBaseActions.php

### DIFF
--- a/classes/CommercePosTransactionBaseActions.php
+++ b/classes/CommercePosTransactionBaseActions.php
@@ -200,12 +200,13 @@ class CommercePosTransactionBaseActions extends CommercePosTransactionBase imple
       $line_item->commerce_pricing_attributes = serialize(array());
     }
 
+ /*
     if (module_exists('commerce_tax')) {
       foreach (commerce_tax_types() as $name => $type) {
         commerce_tax_calculate_by_type($line_item, $name);
       }
     }
-
+*/
     return $this->addLineItem($line_item, $combine);
   }
 


### PR DESCRIPTION
      Have faced this one https://www.drupal.org/node/2824865  It's closed as "Works as designed", yet still affects operations at our side, 
      because taxes are being added twice in certain circumstances.   It seems, commenting out commerce_tax_calculate_by_type fixes issue in our case,  yet it's not quite clear if there are any side effects, caused by code change.  We observe no issues so far, doesn't mean there aren't any.  It seems the piece of code may be obsolete, yet not 100% sure.