### PR TITLE
Fix Fatal error on sale, payment forms when a cashier is deleted

### DIFF
--- a/includes/commerce_pos.payment.inc
+++ b/includes/commerce_pos.payment.inc
@@ -33,7 +33,7 @@ function commerce_pos_payment(&$form, &$form_state, $transaction_type) {
   $form_state['wrapper_id'] = $wrapper_id;
 
   $cashier_id = commerce_pos_cashier_get_current_cashier();
-  if (!$cashier_id) {
+  if (!$cashier_id || !commerce_pos_cashier_load($cashier_id)) {
     drupal_set_message(t('You must log in.'), 'warning');
     $form['message'] = array(
       '#markup' => '<p>' . t('Enter your cashier code.') . '</p>',

--- a/includes/commerce_pos.transaction.inc
+++ b/includes/commerce_pos.transaction.inc
@@ -51,7 +51,7 @@ function commerce_pos_transaction_form(&$form, &$form_state, $transaction_type) 
   $form_state['wrapper_id'] = $wrapper_id;
 
   $cashier_id = commerce_pos_cashier_get_current_cashier();
-  if (!$cashier_id) {
+  if (!$cashier_id || !commerce_pos_cashier_load($cashier_id)) {
     drupal_set_message(t('You must log in.'), 'warning');
     $form['message'] = array(
       '#markup' => '<p>' . t('Enter your cashier code.') . '</p>',

--- a/modules/cashier/commerce_pos_cashier.module
+++ b/modules/cashier/commerce_pos_cashier.module
@@ -240,6 +240,12 @@ function commerce_pos_cashier_form_submit($form, &$form_state) {
 
 /**
  * Loads a cashier by ID.
+ *
+ * @param int $cashier_id
+ *   The ID of a cashier entity.
+ *
+ * @return Entity|FALSE
+ *   A loaded cashier entity or FALSE.
  */
 function commerce_pos_cashier_load($cashier_id) {
   if (empty($cashier_id)) {
@@ -331,9 +337,10 @@ function commerce_pos_cashier_login_form($form, &$form_state) {
 
   // Display label of current cashier.
   if ($cashier_id = commerce_pos_cashier_get_current_cashier()) {
-    /** @var Entity $cashier */
     $cashier = commerce_pos_cashier_load($cashier_id);
-    $form['code']['#title'] = $cashier->label();
+    if ($cashier) {
+      $form['code']['#title'] = $cashier->label();
+    }
   }
   else {
     $form['code']['#attributes']['autofocus'] = TRUE;


### PR DESCRIPTION
This fixes [#2864396](https://www.drupal.org/node/2864396) where a cashier can be deleted but still exist in someone's session.

This no longer attempts to set a cashier label on the cashier login form if the cashier can not be loaded. It also treats an un-loadable cashier the same as not having a cashier id in the session: the sale and payment forms require the user to log in.