### PR TITLE
Fix: Customer email and phone retaining old values on voided transactions

### DIFF
--- a/includes/commerce_pos.transaction.inc
+++ b/includes/commerce_pos.transaction.inc
@@ -589,12 +589,18 @@ function commerce_pos_transaction_ajax_check(&$form, &$form_state) {
         case 'park-transaction':
           $transaction->doAction('park');
           unset($form_state['transaction']);
+          // Need to empty input here as the email and phone numbers are still
+          // retaining the old values after rebuilding the form.
+          $form_state['input'] = array();
           drupal_set_message(t('Transaction @id parked.', array('@id' => $transaction->transactionId)));
           break;
 
         case 'void-transaction':
           $transaction->void();
           unset($form_state['transaction']);
+          // Need to empty input here as the email and phone numbers are still
+          // retaining the old values after rebuilding the form.
+          $form_state['input'] = array();
           drupal_set_message(t('Transaction @id voided.', array('@id' => $transaction->transactionId)));
           break;
 


### PR DESCRIPTION
Issue: https://www.drupal.org/node/2859397. Fix for the customer email and phone retaining old values even after voiding a transaction. Code from helper issue: https://www.drupal.org/node/1350700.