### PR TITLE
fix(commerce_pos): change wording of customer login warning

### DIFF
--- a/includes/commerce_pos.payment.inc
+++ b/includes/commerce_pos.payment.inc
@@ -34,10 +34,7 @@ function commerce_pos_payment(&$form, &$form_state, $transaction_type) {
 
   $cashier_id = commerce_pos_cashier_get_current_cashier();
   if (!$cashier_id || !commerce_pos_cashier_load($cashier_id)) {
-    drupal_set_message(t('You must log in.'), 'warning');
-    $form['message'] = array(
-      '#markup' => '<p>' . t('Enter your cashier code.') . '</p>',
-    );
+    drupal_set_message(t('You must enter your cashier code to proceed.'), 'warning');
     return;
   }
 

--- a/includes/commerce_pos.transaction.inc
+++ b/includes/commerce_pos.transaction.inc
@@ -52,10 +52,7 @@ function commerce_pos_transaction_form(&$form, &$form_state, $transaction_type) 
 
   $cashier_id = commerce_pos_cashier_get_current_cashier();
   if (!$cashier_id || !commerce_pos_cashier_load($cashier_id)) {
-    drupal_set_message(t('You must log in.'), 'warning');
-    $form['message'] = array(
-      '#markup' => '<p>' . t('Enter your cashier code.') . '</p>',
-    );
+    drupal_set_message(t('You must enter your cashier code to proceed.'), 'warning');
     return;
   }
 


### PR DESCRIPTION
Removed the text from the body as well, as it was redundant.

https://www.drupal.org/node/2867505