### PR TITLE
Add commerce_pos_terminal_example.

### DIFF
--- a/modules/terminal_example/CommercePosTerminalExampleService.php
+++ b/modules/terminal_example/CommercePosTerminalExampleService.php
@@ -50,7 +50,7 @@ class CommercePosTerminalExampleService implements CommercePosTerminalServiceInt
       $transaction->remote_status = 'success';
     }
     else {
-      $this->message = 'Even amounts are always unsuccessful';
+      $this->message = 'Odd amounts are always unsuccessful';
       $transaction->status = COMMERCE_PAYMENT_STATUS_FAILURE;
       $transaction->remote_status = 'fail';
     }

--- a/modules/terminal_example/CommercePosTerminalExampleService.php
+++ b/modules/terminal_example/CommercePosTerminalExampleService.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Class CommercePosTerminalExampleService
+ */
+class CommercePosTerminalExampleService implements CommercePosTerminalServiceInterface {
+
+  /**
+   * The message for the transaction.
+   *
+   * @var string
+   */
+  protected $message = '';
+
+  /**
+   * CommercePosTerminalExampleService constructor.
+   */
+  public function __construct() {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPaymentType() {
+    return 'credit';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getPaymentTypes() {
+    return array(
+      'credit' => t('Credit'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function purchase($transaction) {
+    $amount = $transaction->amount / 100;
+    $cents = $amount - floor($amount);
+    if ($cents > 0) {
+      sleep($cents * 100);
+    }
+
+    if ($amount % 2 === 0) {
+      $this->message = 'Even amounts are always successful';
+      $transaction->status = COMMERCE_PAYMENT_STATUS_SUCCESS;
+      $transaction->remote_status = 'success';
+    }
+    else {
+      $this->message = 'Even amounts are always unsuccessful';
+      $transaction->status = COMMERCE_PAYMENT_STATUS_FAILURE;
+      $transaction->remote_status = 'fail';
+    }
+
+    $transaction->message = $this->message;
+    $transaction->remote_id = rand(1000, 9999);
+    return $transaction;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function refund($transaction) {
+    return $this->purchase($transaction);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function void($transaction) {
+    return array(
+      'success' => TRUE,
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTransactionMessage() {
+    return $this->message;
+  }
+
+  /**
+   * {@ineritdoc}
+   */
+  public function saved() {
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setLocation($location_id = NULL) {
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setRegister($register_id = NULL) {
+    return $this;
+  }
+
+}

--- a/modules/terminal_example/README.md
+++ b/modules/terminal_example/README.md
@@ -1,0 +1,20 @@
+# Commerce POS Terminal Example
+
+This module integrates with commerce_pos_terminal to provide a fake terminal
+service plugin.
+
+The plugin is for testing or development of the terminal module without
+requiring a real payment terminal.
+
+## Testing behaviors
+
+To support testing different scenarios, the plugin has the following behavior:
+* Transactions with even dollar amounts always succeed.
+* Transactions with odd dollar amounts always fail.
+* The process sleeps for one second for every cent in the transaction amount.
+  This is to simulate the real delay of a user operating a payment terminal.
+
+## Installation and configuration
+
+Enable the module and select it as the terminal service plugin in the
+configuration of the commerce_pos_terminal module.

--- a/modules/terminal_example/commerce_pos_terminal_example.info
+++ b/modules/terminal_example/commerce_pos_terminal_example.info
@@ -1,0 +1,4 @@
+name = Commerce POS Terminal Example
+description = Provides an example terminal service for commece_pos_terminal
+core = 7.x
+package = Commerce POS

--- a/modules/terminal_example/commerce_pos_terminal_example.module
+++ b/modules/terminal_example/commerce_pos_terminal_example.module
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * Hook implementations and related functions.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function commerce_pos_terminal_example_menu() {
+  $items['admin/commerce/config/pos/terminal/terminal_example'] = array(
+    'title' => 'Terminal Example',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('commerce_pos_terminal_example_settings_form'),
+    'access arguments' => array('administer commerce pos'),
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_commerce_pos_terminal_service_info().
+ */
+function commerce_pos_terminal_example_commerce_pos_terminal_service_info() {
+  $server['commerce_pos_terminal_example'] = array(
+    'name' => 'commerce_pos_terminal_example',
+    'label' => t('Example Terminal Service'),
+    'class' => 'CommercePosTerminalExampleService',
+    'file' => drupal_get_path('module', 'commerce_pos_terminal_example') . '/CommercePosTerminalExampleService.php',
+    'configure' => 'admin/commerce/config/pos/terminal/terminal_example',
+  );
+
+  return $server;
+}
+
+/**
+ * Form function for the example terminal settings.
+ */
+function commerce_pos_terminal_example_settings_form(array $form, array $form_state) {
+  $form['markup'] = array(
+    '#markup' => '<p>' . t('Any even amount will be approved and any odd amount will be rejected.') . '</p>',
+  );
+
+  return $form;
+}


### PR DESCRIPTION
This solves d.o issue [2871643 - Add an example terminal service plugin for development](https://www.drupal.org/node/2871643).

It has a few funky behaviors for testing success, failure, or delays and timeouts which are documented in a README.

* Transactions with even dollar amounts always succeed.
* Transactions with odd dollar amounts always fail.
* The process sleeps for one second for every cent in the transaction amount.
   This is to simulate the real delay of a user operating a payment terminal.

I don't have strong feeling towards making things configurable (its settings form currently has no settings), changing how it behaves now or in the future, or, since it's a developer module, leaving it as-is and expecting people to just change the code if they want to disable the sleep thing or whatever.