### PR TITLE
fix(commerce_pos_report): support all results per page

### DIFF
--- a/modules/report/includes/commerce_pos_report.pages.inc
+++ b/modules/report/includes/commerce_pos_report.pages.inc
@@ -809,7 +809,9 @@ function commerce_pos_report_build_journal_role_table(array $filters = array()) 
     ->extend('PagerDefault')
     ->extend('TableSort');
 
-  $query->limit($filters['results_per_page']);
+  if ($filters['results_per_page'] > 0) {
+    $query->limit($filters['results_per_page']);
+  }
 
   $query->fields('t', array('order_id', 'completed', 'uid', 'type'));
 


### PR DESCRIPTION
Fixes an issue with results per page set to all.

https://www.drupal.org/node/2875908