### PR TITLE
fix(commerce_pos): show error message correctly when changing quantity

### DIFF
--- a/includes/commerce_pos.transaction.inc
+++ b/includes/commerce_pos.transaction.inc
@@ -452,6 +452,7 @@ function commerce_pos_transaction_form(&$form, &$form_state, $transaction_type) 
         '#attributes' => array(
           'class' => array('commerce-pos-hidden-element'),
         ),
+        '#limit_validation_errors' => FALSE,
       );
 
       $line_item_element['textbox_wrapper_close'] = array(
@@ -691,6 +692,15 @@ function _commerce_pos_transaction_validate_product_input($element, &$form_state
  */
 function _commerce_pos_transaction_validate_qty($element, &$form_state, $form) {
   $requested_qty = drupal_array_get_nested_value($form_state['input'], $element['#parents']);
+
+  // If the increment or decrement buttons were used, we need to add/subtract
+  // from the requested_qty.
+  if ($form_state['triggering_element']['#element_key'] == 'line-item-remove-qty') {
+    $requested_qty -= 1;
+  }
+  if ($form_state['triggering_element']['#element_key'] == 'line-item-add-qty') {
+    $requested_qty += 1;
+  }
 
   if (is_numeric($requested_qty) && $requested_qty > 0) {
     form_set_value($element, $requested_qty, $form_state);


### PR DESCRIPTION
This fixes two issues:

1) The increment/decrement quantity buttons were incorrectly using the unadjusted amount as the requested quantity in the validation handler. This made it so that decrementing to 0 was possible without triggering the error, but it resulted in the product being removed from the transaction so this may have been perceived as a 'feature'. Instead, we should show the error as intended and require the usage of the 'X' button to remove an item from a cart.

2) Manually inputting an incorrect number (0 or less than 0 or non-numeric input) didn't show the error message, it just didn't work. This is now fixed so that the error message is shown.

https://www.drupal.org/node/2866843