### PR TITLE
fix(commerce_pos_upc_scan): support fields with different value columns

### DIFF
--- a/modules/upc_scan/commerce_pos_upc_scan.module
+++ b/modules/upc_scan/commerce_pos_upc_scan.module
@@ -75,23 +75,27 @@ function commerce_pos_upc_scan_commerce_pos_sale_form_ajax_alter(&$form_state, $
  * Attempts to look up a product by its UPC.
  */
 function commerce_pos_upc_scan_lookup($upc) {
-  $product_id = NULL;
-
   if (!empty($upc) && is_numeric($upc) && $upc_field = variable_get('commerce_pos_upc_scan_upc_field', FALSE)) {
     if ($upc_field == 'sku') {
       $query = db_select('commerce_product', 'cp')
         ->fields('cp', array('product_id'))
         ->condition('sku', $upc);
+      $product_id = $query->execute()->fetchField();
     }
     else {
-      $query = db_select('field_data_' . $upc_field, 'f')
-        ->fields('f', array('entity_id'))
-        ->condition('entity_type', 'commerce_product')
-        ->condition($upc_field . '_value', $upc);
-    }
+      $query = new EntityFieldQuery();
+      list($field_name, $value_column_name) = explode('|', $upc_field);
+      $query->entityCondition('entity_type', 'commerce_product')
+        ->fieldCondition($field_name, $value_column_name, $upc, '=')
+        // Run the query as user 1.
+        ->addMetaData('account', user_load(1));
 
-    $product_id = $query->execute()->fetchField();
+      $result = $query->execute();
+      if (!empty($result['commerce_product'])) {
+        $product_id = array_keys($result['commerce_product'])[0];
+      }
+    }
   }
 
-  return $product_id;
+  return !empty($product_id) ? $product_id : FALSE;
 }

--- a/modules/upc_scan/includes/commerce_pos_upc_scan.admin.inc
+++ b/modules/upc_scan/includes/commerce_pos_upc_scan.admin.inc
@@ -14,9 +14,12 @@ function commerce_pos_upc_scan_settings($form, &$form_state) {
     'sku' => t('Base SKU field'),
   );
 
+  $field_info = field_info_fields();
   foreach (field_info_instances('commerce_product') as $bundle_name => $fields) {
     foreach ($fields as $field_name => $field) {
-      $field_options[$field_name] = $field_name;
+      foreach (array_keys($field_info[$field_name]['columns']) as $column_name) {
+        $field_options[$field_name][$field_name . '|' . $column_name] = $field_name . ' (' . $column_name . ')';
+      }
     }
   }
 


### PR DESCRIPTION
This fix makes it possible to use fields with different value columns instead of just forcing the 'value' column and crashing when it doesn't exist.

https://www.drupal.org/node/2838948