### PR TITLE
Remove reference to unset ['transaction']

### DIFF
--- a/includes/commerce_pos.payment.inc
+++ b/includes/commerce_pos.payment.inc
@@ -38,12 +38,8 @@ function commerce_pos_payment($form, &$form_state) {
 
   $payment_options = commerce_pos_get_payment_options();
   $form['#theme'] = 'commerce_pos_payment';
-  // Make sure we are dealing with the right type of transaction.
-  $form_state['transaction']->updateType();
-  $transaction_type = $form_state['transaction']->type;
-  $return = $transaction_type == CommercePosService::TRANSACTION_TYPE_RETURN;
 
-  $form['#prefix'] = '<div id="' . $wrapper_id . '" class="' . ($return ? 'return' : 'sale') . '">';
+  $form['#prefix'] = '<div id="' . $wrapper_id . '" class="sale">';
   $form['#suffix'] = '</div>';
 
   $form_ajax = array(


### PR DESCRIPTION
The `$form_state['transaction']` is unset in the `commerce_pos_payment_ajax_check()` and is causing issues on the payment form.